### PR TITLE
Fix `recipe-maintainers`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,5 +89,5 @@ about:
   summary: 'PyUtilib: A collection of Python utilities'
 
 extra:
-  - recipe-maintainers:
+  recipe-maintainers:
     - whart222


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge.github.io/issues/86

Had a minor syntax error. This removes it. Was causing this [error](https://travis-ci.org/conda-forge/conda-forge.github.io/jobs/122659832#L242).
